### PR TITLE
API yaml definition parser - initial implementation

### DIFF
--- a/spec-schema/parser/.gitignore
+++ b/spec-schema/parser/.gitignore
@@ -1,0 +1,3 @@
+adoc_output/
+output/
+.vscode

--- a/spec-schema/parser/doc_gen.py
+++ b/spec-schema/parser/doc_gen.py
@@ -107,9 +107,7 @@ def generate_c_module_adoc(module, out_dir):
     if 'c-specific-notes' in module.keys():
         out_str += format_text_from_array(module['c-specific-notes'])
         out_str += "\n"
-        
-    out_str += "== Defines\n"
-        
+                
     out_str += "== Types\n"
     
     # Add type declarations

--- a/spec-schema/parser/doc_gen.py
+++ b/spec-schema/parser/doc_gen.py
@@ -58,8 +58,8 @@ def format_adoc_function(function, module_type_list):
         
     out_str += "==== Return\n"
     
-    if 'c-return-type' in function.keys():
-        out_str += "`" + function['c-return-type']['type'] + "` - " + function['c-return-type']['description'] + "\n\n"
+    if 'c-return-value' in function.keys():
+        out_str += "`" + function['c-return-value']['type'] + "` - " + function['c-return-value']['description'] + "\n\n"
     
     out_str += "==== Parameters\n"
     

--- a/spec-schema/parser/doc_gen.py
+++ b/spec-schema/parser/doc_gen.py
@@ -1,0 +1,145 @@
+import pathlib
+
+def format_text_from_array(input_array):
+    out_str = ""
+    
+    for item in input_array:
+        out_str += item
+        out_str += "\n"
+    return out_str
+
+def format_adoc_type_declaration(declaration):     
+    # values can be "struct", "enum", "int", "unsigned"
+    c_type = declaration['type'] 
+
+    out_str = "=== " + c_type + " *" + declaration['name'] + "*\n"
+    out_str += declaration['description'] + "\n\n" 
+            
+    if c_type == "enum":
+        out_str += "==== Values\n"
+        
+        for member in declaration['enum-members']:
+            out_str += "*" + member['name'] + "*\n\n" 
+
+    if c_type == "struct":
+        out_str += "==== Members\n"
+
+        for member in declaration['struct-members']:
+            member_type = member['type']
+            delimiter = " "
+            if member_type[-1] == '*': # pointer
+                delimiter = ""
+            out_str += member_type + delimiter + member['name'] + "\n\n"
+                             
+    return out_str
+
+def format_adoc_function(function):
+    
+    out_str = "=== " + function['name'] + "\n"
+    out_str += function['description'] + "\n\n"
+        
+    out_str += "==== Return\n"
+    
+    if 'c-return-type' in function.keys():
+        out_str += "`" + function['c-return-type']['type'] + "` - " + function['c-return-type']['description'] + "\n\n"
+    
+    out_str += "==== Parameters\n"
+    
+    if 'c-params' in function.keys():
+        for param in function['c-params']:
+                        
+            param_type = param['type']
+            delimiter = " "
+            if param_type[-1] == '*': # pointer
+                delimiter = ""
+                    
+            out_str += "`" + param_type + delimiter + param['name'] + "` - " + param['description'] + "\n\n"
+            
+            if 'notes' in param.keys():
+                out_str += format_text_from_array(param['notes'])
+            out_str += "\n"
+                
+    else:
+        out_str += "Function takes no parameters\n\n"
+    
+
+    
+    return out_str   
+
+def generate_c_module_adoc(module, out_dir):
+        
+    filename = module['c-filename'].lower().replace('.','_') + ".adoc"    
+    out_file = pathlib.Path(out_dir, filename)
+    
+    out_str = "[#title]\n"
+    out_str += "= " + module['c-filename'] + " - " + module['name'] + "\n"
+    out_str += ":toc:\n"
+    
+    out_str += module['description'] + "\n\n"
+    
+    out_str += "== Notes\n"
+    
+    if 'notes' in module.keys():
+        out_str += format_text_from_array(module['notes'])
+        out_str += "\n"
+    
+    if 'c-specific-notes' in module.keys():
+        out_str += format_text_from_array(module['c-specific-notes'])
+        out_str += "\n"
+        
+    out_str += "== Defines\n"
+        
+    out_str += "== Types\n"
+    
+    # Add type declarations
+    if 'c-type-declarations' in module.keys():
+        for type_declaration in module['c-type-declarations']:
+            out_str += format_adoc_type_declaration(type_declaration)
+            out_str += "\n"
+        out_str += "\n"
+    
+    out_str += "== Functions\n"
+    
+    # Add function declarations
+    if 'functions' in module.keys():
+        for function in module['functions']:
+            out_str += format_adoc_function(function)
+            out_str += "\n"
+        out_str += "\n"      
+    
+    
+    # Write to the output file
+    out_file.parent.mkdir(exist_ok=True, parents=True)
+    out_file.write_text(out_str)
+    
+    return module['c-filename'],module['name'],filename
+
+def generate_c_adoc(api_definition, out_dir):
+    
+    # Top level file
+    filename =  api_definition['c-documentation-title'].lower().replace(' ','_') + ".adoc"
+    
+    out_file = pathlib.Path(out_dir, filename)
+    out_str = "= " + api_definition['c-documentation-title'] + "\n"
+    
+    if 'notes' in api_definition.keys():
+        out_str += format_text_from_array(api_definition['notes'])
+        out_str += "\n"
+    
+    if 'c-specific-notes' in api_definition.keys():
+        out_str += format_text_from_array(api_definition['c-specific-notes'])
+        out_str += "\n"
+    
+    out_str += "== Modules\n"
+    
+    for module in api_definition['modules']:
+        # Generate docs for module - this will be a new file
+        # Returns [c filename, module name, adoc filename]
+        module_links = generate_c_module_adoc(module, out_dir)
+    
+        # Add link to a table of contents
+        out_str += "* xref:" + module_links[2] + "#title[" + module_links[0] + "] - " + module_links[1] + "\n"
+    
+    # Write to the output file
+    out_file.parent.mkdir(exist_ok=True, parents=True)
+    out_file.write_text(out_str)

--- a/spec-schema/parser/doc_gen.py
+++ b/spec-schema/parser/doc_gen.py
@@ -1,6 +1,7 @@
 import pathlib
 
 def format_text_from_array(input_array):
+    ''' Concatenates an array of strings into a single return string.'''
     out_str = ""
     
     for item in input_array:
@@ -8,7 +9,11 @@ def format_text_from_array(input_array):
         out_str += "\n"
     return out_str
 
-def format_adoc_type_declaration(declaration):     
+def format_adoc_type_declaration(declaration):
+    ''' Builds adoc level 3 & 4 section for supplied type declaration.
+        Returns this as a string.
+    '''
+         
     # values can be "struct", "enum", "int", "unsigned"
     c_type = declaration['type'] 
     
@@ -35,10 +40,16 @@ def format_adoc_type_declaration(declaration):
     return out_str
 
 def format_adoc_function(function, module_type_list):
+    ''' Builds adoc level 3 & 4 section for supplied function declaration.
+        Second parameter is a list of types declared within this module which
+        is used to create cross-references.
+        Returns function adoc string.
+    '''
     
     def format_param_type(type,types_defined_by_module):
+        ''' If parameter type is defined within module then render this as a cross-reference'''
         if type in types_defined_by_module:
-            return "<<type_" + type + ",`" + type + "`>>"
+            return "<<type_" + type + ",`" + type + "`>>" # Adoc cross-reference to type
         else:
             return type
         
@@ -73,6 +84,10 @@ def format_adoc_function(function, module_type_list):
     return out_str   
 
 def generate_c_module_adoc(module, out_dir):
+    ''' Builds adoc file for a module.
+        Inputs are the module definition and the output directory for the
+        adoc file.
+    '''
         
     filename = module['c-filename'].lower().replace('.','_') + ".adoc"    
     out_file = pathlib.Path(out_dir, filename)
@@ -124,6 +139,12 @@ def generate_c_module_adoc(module, out_dir):
     return module['c-filename'],module['name'],filename
 
 def generate_c_adoc(api_definition, out_dir):
+    ''' Top level function which builds a top level index adoc file then 
+        iterates through modules defined in the api definition to build module
+        documentation.
+        Input parameters are the api_definition object and the output directory 
+        for the adoc files. 
+    '''
     
     # Top level file
     filename =  api_definition['c-documentation-title'].lower().replace(' ','_') + ".adoc"

--- a/spec-schema/parser/doc_gen.py
+++ b/spec-schema/parser/doc_gen.py
@@ -38,7 +38,7 @@ def format_adoc_function(function, module_type_list):
     
     def format_param_type(type,types_defined_by_module):
         if type in types_defined_by_module:
-            return "<<type_" + type + ",`" + type + "`>> "
+            return "<<type_" + type + ",`" + type + "`>>"
         else:
             return type
         

--- a/spec-schema/parser/doc_gen.py
+++ b/spec-schema/parser/doc_gen.py
@@ -58,7 +58,7 @@ def format_adoc_function(function, module_type_list):
             param_type = param['type']
             param_name = param['name']
             if param_type[-1] == '*': # pointer
-                param_type = param_type.rstrip('*')
+                param_type = param_type.rstrip('* ')
                 param_name = "*" + param_name
                                         
             out_str += format_param_type(param_type, module_type_list) + " `" + param_name + "` - " + param['description'] + "\n\n"

--- a/spec-schema/parser/header_gen.py
+++ b/spec-schema/parser/header_gen.py
@@ -113,8 +113,8 @@ def format_c_function(function):
     out_str += "*/\n"
     
     return_type = "void" 
-    if 'c-return-type' in function.keys():
-        return_type = function['c-return-type']['type']
+    if 'c-return-value' in function.keys():
+        return_type = function['c-return-value']['type']
     
     out_str += return_type + " " + function['name'] + "("
     if 'c-params' in function.keys():

--- a/spec-schema/parser/header_gen.py
+++ b/spec-schema/parser/header_gen.py
@@ -100,11 +100,13 @@ def format_c_function(function):
         for param in function['c-params']:
             
             param_type = param['type']
-            delimiter = " "
-            if param_type[-1] == '*': # pointer
-                delimiter = ""
-                    
-            out_str += param_type + delimiter + param['name'] + ", "
+            param_name = param['name']
+            if param_type[-1] == '*':
+                # pointer types - present with spacing as "int *a" 
+                param_type = param_type.rstrip('* ')
+                param_name = "*" + param_name
+                                                                    
+            out_str += param_type + " " + param_name + ", "
         
         out_str = out_str.rstrip(", ") # Get rid of last comma/space
         

--- a/spec-schema/parser/header_gen.py
+++ b/spec-schema/parser/header_gen.py
@@ -1,12 +1,21 @@
 import textwrap, pathlib
 
 def format_c_comment_lines(input_string):
+    ''' Takes a string as input. 
+        Returns input string wrapped to 80 chars with each line pre-prepended 
+        with an asterix so they can be used in a C comment. 
+    '''
     out_str = ""
     for lines in textwrap.wrap(input_string,80):
         out_str += ("* " + lines).rstrip() + "\n "
     return out_str
 
 def format_c_comment_lines_from_array(input_array):
+    ''' Takes an array of strings to be used as comments.  
+        Returns a string with the array concatenated into comment line.
+        Return string does not have comment terminator (*/).
+    '''
+    
     out_str = ""
     for item in input_array:
         out_str += format_c_comment_lines(item)
@@ -14,6 +23,10 @@ def format_c_comment_lines_from_array(input_array):
     return out_str    
 
 def format_c_include_file(include_file):
+    ''' Takes an include file object.
+        Returns a string with the file built into a C include line
+    '''
+    
     out_str = ""
     if (include_file['system-header']):
         out_str += "#include <" + include_file['filename'] + ">\n"   
@@ -22,8 +35,12 @@ def format_c_include_file(include_file):
     return out_str    
 
 def format_c_type_prefix_list(prefix_list):
-    # values can be ["const", "static", "volatile", "inline"]
-    # order is important for C compilation
+    ''' Takes a list of C prefixes to be applied to a type definition.
+        Values can be ["const", "static", "volatile", "inline"].
+        Returns a string with these concatenated together in the correct order
+        for C compilation.
+    '''
+    
     out_str = ""
     if "static" in prefix_list:
         out_str += "static "
@@ -76,13 +93,17 @@ def format_c_type_declaration(declaration):
     else:
         raise('undefined C type definition')   # Should not be possible to reach here            
     
-    # TODO does it make sense to have prefixes with typedefs ??
-    #if 'type-prefixes' in declaration.keys():
-    #    out_str = format_c_type_prefix_list(declaration['type-prefixes']) + out_str
+    if 'type-prefixes' in declaration.keys():
+        out_str = format_c_type_prefix_list(declaration['type-prefixes']) + out_str
                      
     return out_str
 
 def format_c_function(function):
+    ''' Takes a function object.
+        Returns a string containing the function formatted as a C function
+        prototype.
+    '''
+    
     # Start the comment.
     out_str = "/*\n "
         
@@ -117,6 +138,11 @@ def format_c_function(function):
     return out_str     
 
 def generate_c(api_definition, out_dir):
+    ''' Top level function which iterates through each of the modules in the api definition 
+        to build C header content and write it an appropriate file.
+        Input parameters are the api_definition object and the output directory for the header files 
+    '''
+    
     for module in api_definition['modules']:
         
         out_file = pathlib.Path(out_dir, module['c-filename'])

--- a/spec-schema/parser/header_gen.py
+++ b/spec-schema/parser/header_gen.py
@@ -1,0 +1,169 @@
+import textwrap, pathlib
+
+def format_c_comment_lines(input_string):
+    out_str = ""
+    for lines in textwrap.wrap(input_string,80):
+        out_str += ("* " + lines).rstrip() + "\n "
+    return out_str
+
+def format_c_comment_lines_from_array(input_array):
+    out_str = ""
+    for item in input_array:
+        out_str += format_c_comment_lines(item)
+        out_str += "*\n "
+    return out_str    
+
+def format_c_include_file(include_file):
+    out_str = ""
+    if (include_file['system-header']):
+        out_str += "#include <" + include_file['filename'] + ">\n"   
+    else:
+        out_str += "#include \"" + include_file['filename'] + "\"\n"
+    return out_str    
+
+def format_c_type_prefix_list(prefix_list):
+    # values can be ["const", "static", "volatile", "inline"]
+    # order is important for C compilation
+    out_str = ""
+    if "static" in prefix_list:
+        out_str += "static "
+        
+    if "volatile" in prefix_list:
+        out_str += "volatile "
+        
+    if "inline" in prefix_list:
+        out_str += "inline "        
+
+    if "const" in prefix_list:
+        out_str += "const "
+        
+    return out_str
+    
+def format_c_type_declaration(declaration):
+    def indent():
+        return "    "   # indent 4 spaces 
+    
+    out_str = ""
+     
+    # values can be "struct", "enum", "int", "unsigned"
+    c_type = declaration['type']
+    if c_type == "int":
+        out_str += "typedef int " + declaration['name'] + ";\n"
+        
+    elif c_type == "unsigned":
+        out_str += "typedef unsigned int " + declaration['name'] + ";\n"
+        
+    elif c_type == "enum":
+        out_str += "typedef enum {\n"
+        for member in declaration['enum-members']:
+            out_str += indent() + member['name'] 
+            if 'value' in member.keys():
+                out_str += " = " + str(member['value']) 
+            out_str += ",\n" # trailing comma should be valid for modern compilers
+        out_str += "} " + declaration['name'] + ";\n"
+            
+    elif c_type == "struct":
+        out_str += "typedef struct {\n"
+        for member in declaration['struct-members']:
+            member_type = member['type']
+            delimiter = " "
+            if member_type[-1] == '*': # pointer
+                delimiter = ""
+            
+            out_str += indent() + member_type + delimiter + member['name'] + ";\n"
+        out_str += "} " + declaration['name'] + ";\n"
+        
+    else:
+        raise('undefined C type definition')   # Should not be possible to reach here            
+    
+    # TODO does it make sense to have prefixes with typedefs ??
+    #if 'type-prefixes' in declaration.keys():
+    #    out_str = format_c_type_prefix_list(declaration['type-prefixes']) + out_str
+                     
+    return out_str
+
+def format_c_function(function):
+    # Start the comment.
+    out_str = "/*\n "
+        
+    out_str += format_c_comment_lines(function['description'])
+            
+    # Close comment
+    out_str += "*/\n"
+    
+    return_type = "void" 
+    if 'c-return-type' in function.keys():
+        return_type = function['c-return-type']['type']
+    
+    out_str += return_type + " " + function['name'] + "("
+    if 'c-params' in function.keys():
+        for param in function['c-params']:
+            
+            param_type = param['type']
+            delimiter = " "
+            if param_type[-1] == '*': # pointer
+                delimiter = ""
+                    
+            out_str += param_type + delimiter + param['name'] + ", "
+        
+        out_str = out_str.rstrip(", ") # Get rid of last comma/space
+        
+    else:
+        out_str += "void"       
+    
+    out_str +=");\n"
+    return out_str     
+
+def generate_c(api_definition, out_dir):
+    for module in api_definition['modules']:
+        
+        out_file = pathlib.Path(out_dir, module['c-filename'])
+        
+        # Start the comment.
+        out_str = "/*\n "
+        
+        # Insert the module name,  description & boilerplate strings line per line
+        out_str += format_c_comment_lines(module['name'])
+        out_str += "*\n "
+        
+        out_str += format_c_comment_lines(module['description'])
+        out_str += "*\n "
+        
+        out_str += format_c_comment_lines(api_definition['boilerplate'])
+
+        # Close comment
+        out_str += "*/\n\n"
+
+        # Guard against multiple inclusion with define based on filename, e.g. csi_defs.h => CSI_DEFS_H 
+        def_file_name = pathlib.Path(out_file).name.upper().replace('.','_')
+        out_str += "#ifndef " + def_file_name + "\n"
+        out_str += "#define " + def_file_name + "\n"
+        
+        out_str += "\n"
+        
+        # Add include files        
+        if 'c-include-files' in module.keys():
+            for include_file in module['c-include-files']:
+                out_str += format_c_include_file(include_file)
+            out_str += "\n"
+                    
+        # Add type declarations
+        if 'c-type-declarations' in module.keys():
+            for type_declaration in module['c-type-declarations']:
+                out_str += format_c_type_declaration(type_declaration)
+                out_str += "\n"
+            out_str += "\n"
+            
+        # Add function declarations
+        if 'functions' in module.keys():
+            for function in module['functions']:
+                out_str += format_c_function(function)
+                out_str += "\n"
+            out_str += "\n"        
+                
+        # Close guard against multiple inclusion
+        out_str += "#endif /* " + def_file_name + " */ \n"
+        
+        # Write to the output file
+        out_file.parent.mkdir(exist_ok=True, parents=True)
+        out_file.write_text(out_str)

--- a/spec-schema/parser/header_gen_test.py
+++ b/spec-schema/parser/header_gen_test.py
@@ -1,0 +1,11 @@
+import unittest, header_gen
+
+class Test_Parser_Units(unittest.TestCase):
+    def test_should_format_include_statements(self):
+        include_file = {'filename':'stdio.h', 'system-header':True}
+        self.assertEqual(header_gen.format_c_include_file(include_file), "#include <stdio.h>\n")
+        include_file = {'filename':'csi.h', 'system-header':False}
+        self.assertEqual(header_gen.format_c_include_file(include_file), "#include \"csi.h\"\n")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/spec-schema/parser/parser.py
+++ b/spec-schema/parser/parser.py
@@ -6,6 +6,8 @@ default_schema_file_path = "../"
 default_schema_file_name = "rvm-csi.schema.json"
 
 def parse_arguments(argv):
+    ''' Parses command land args using standard Python module.'''
+    
     parser = argparse.ArgumentParser(description="Parse RVM CSI API yaml definition to generate language specific header files")
     parser.add_argument("infile", help="Input yaml file defining API")
     parser.add_argument("--out-dir", dest='out_dir', default='output', help="Output directory")
@@ -16,17 +18,27 @@ def parse_arguments(argv):
     return parser.parse_args(argv)
 
 def load_api_definition(file_name):
+    ''' Loads yaml deifnition from file.'''
+    
     with open(file_name,'r') as yaml_in:
         return yaml.safe_load(yaml_in)
 
 def load_api_schema(file_name):
+    ''' Loads json schema for api from file
+        In the future this may be loaded from an online source.
+    '''
+    
     with open(file_name,'r') as json_schema_in:
         return json.load(json_schema_in)
         
 def validate_json_schema(api_definition, schema):
+    ''' Validates api definition against schema to ensure it is valid.'''
+    
     jsonschema.validate(api_definition, schema)
     
 def generate_documentation(api_definition, opts):
+    ''' Calls language appropriate documentation generation function.'''
+    
     target_language = opts.target_language
     if target_language == "C":
         doc_gen.generate_c_adoc(api_definition, opts.doc_out_dir)
@@ -34,6 +46,8 @@ def generate_documentation(api_definition, opts):
         raise('Target language implementation undefined')
     
 def generate_headers(api_definition, opts):
+    ''' Calls language appropriate header generation function.'''
+    
     target_language = opts.target_language
     if target_language == "C":
         header_gen.generate_c(api_definition, opts.out_dir)
@@ -41,6 +55,11 @@ def generate_headers(api_definition, opts):
         raise('Target language implementation undefined')
         
 def main(argv):
+    ''' Parser top level - invoked from command line
+        Builds either header files or adoc documentation from
+        a validated yaml api description,
+    '''
+    
     options = parse_arguments(argv)
     api_definition = load_api_definition(options.infile)
     

--- a/spec-schema/parser/parser.py
+++ b/spec-schema/parser/parser.py
@@ -1,0 +1,60 @@
+import sys, json
+import argparse, yaml, jsonschema
+import header_gen, doc_gen
+
+default_schema_file_path = "../"
+default_schema_file_name = "rvm-csi.schema.json"
+
+def parse_arguments(argv):
+    parser = argparse.ArgumentParser(description="Parse RVM CSI API yaml definition to generate language specific header files")
+    parser.add_argument("infile", help="Input yaml file defining API")
+    parser.add_argument("--out-dir", dest='out_dir', default='output', help="Output directory")
+    parser.add_argument("--generate-docs", dest='generate_docs',action='store_true', default=False, help="Generate documentaton")
+    parser.add_argument("--doc-out-dir", dest='doc_out_dir', default='adoc_output', help="Documentation output directory")
+    parser.add_argument("--target-language", dest='target_language',choices=['C'], default='C', help="Target language")
+
+    return parser.parse_args(argv)
+
+def load_api_definition(file_name):
+    with open(file_name,'r') as yaml_in:
+        return yaml.safe_load(yaml_in)
+
+def load_api_schema(file_name):
+    with open(file_name,'r') as json_schema_in:
+        return json.load(json_schema_in)
+        
+def validate_json_schema(api_definition, schema):
+    jsonschema.validate(api_definition, schema)
+    
+def generate_documentation(api_definition, opts):
+    target_language = opts.target_language
+    if target_language == "C":
+        doc_gen.generate_c_adoc(api_definition, opts.doc_out_dir)
+    else: 
+        raise('Target language implementation undefined')
+    
+def generate_headers(api_definition, opts):
+    target_language = opts.target_language
+    if target_language == "C":
+        header_gen.generate_c(api_definition, opts.out_dir)
+    else: 
+        raise('Target language implementation undefined')
+        
+def main(argv):
+    options = parse_arguments(argv)
+    api_definition = load_api_definition(options.infile)
+    
+    # TODO work out where schema will be stored - in common repository?
+    schema = load_api_schema(default_schema_file_path + default_schema_file_name)
+
+    validate_json_schema(api_definition, schema)
+    
+    if (options.generate_docs):
+        return generate_documentation(api_definition, options)
+    else: 
+        return generate_headers(api_definition, options)
+            
+if __name__ == '__main__':
+    main(sys.argv[1:])
+
+

--- a/spec-schema/parser/parser_test.py
+++ b/spec-schema/parser/parser_test.py
@@ -1,0 +1,36 @@
+import unittest, jsonschema, os
+import parser
+
+test_data_file_path = "./test_data/"
+
+class Test_Parser_Top_Level(unittest.TestCase):
+    def test_should_provide_command_line_help(self):
+        try:
+            parser.main(["--help"])
+            self.assertEqual("Should not reach this statement",None)
+        except SystemExit as e:
+            self.assertEqual(e.code, 0)
+        
+    def test_should_throw_error_if_input_file_is_not_found(self):
+        try:
+            parser.main(["foo.yaml"])
+            self.assertEqual("Should not reach this statement",None)
+        except FileNotFoundError as e:
+            self.assertEqual(e.strerror, "No such file or directory")
+            
+    def test_should_throw_error_if_input_yaml_does_not_match_schema(self):
+        try:
+            test_file = test_data_file_path + "invalid.rvm-csi.yaml"
+            output = parser.main([test_file])
+            self.assertEqual("Should not reach this statement",None)
+        except jsonschema.exceptions.ValidationError as e:
+            self.assertEqual(e.message, "Additional properties are not allowed ('another-duff-property' was unexpected)")            
+
+    def test_should_build_header_files_for_c_language(self):
+        test_file = test_data_file_path + "simple.rvm-csi.yaml"
+        parser.main([test_file])
+        self.assertEqual(os.path.isfile("./output/csi.h"), True)
+        self.assertEqual(os.path.isfile("./output/csi_interrupts.h"), True)
+        self.assertEqual(os.path.isfile("./output/csi_discovery.h"), True)
+        self.assertEqual(os.path.isfile("./output/csi_defs.h"), True)        
+

--- a/spec-schema/parser/readme.md
+++ b/spec-schema/parser/readme.md
@@ -1,0 +1,37 @@
+# Schema Parser
+
+## Prerequisites
+
+* A Python installation ($\ge$ v3) 
+* Install script specific python modules `jsonschema` & `PyYaml` .  Can be install using `pip install -r requirements.txt`
+
+## Usage Examples
+
+### Header file generation
+
+Builds a set of header files, placing them in default directory `./output`
+
+`python3 parser.py ./test_data/simple.rvm-csi.yaml`
+
+### Adoc file generation
+
+Builds a set of header files, placing them in default directory `./adoc_output`
+
+`python3 parser.py --generate-docs ./test_data/simple.rvm-csi.yaml`
+
+Linked HTML docs can be generated from the .adoc files e.g.
+
+`cd ./adoc_output`
+`asciidoctor *.adoc`
+
+## Testing
+
+*NB incomplete*
+
+Top level parser tests:
+
+`python3 parser_test.py`
+
+Header generation tests:
+
+`python3 header_gen_test.py`

--- a/spec-schema/parser/readme.md
+++ b/spec-schema/parser/readme.md
@@ -39,8 +39,8 @@ The .adoc files can be transformed to HTML using [Asciidoctor](https://asciidoct
 
 Top level parser tests:
 
-`python3 parser_test.py`
+`python3 -m unittest -v parser_test.py`
 
 Header generation tests:
 
-`python3 header_gen_test.py`
+`python3 -m unittest -v header_gen_test.py`

--- a/spec-schema/parser/readme.md
+++ b/spec-schema/parser/readme.md
@@ -1,32 +1,41 @@
-# Schema Parser
+# API Definition Parser
+
+## Overview
+
+A Python application which will parse a YAML RVM-CSI API definition file, validate it against the official schema, then generate either a set of C header files or a set of AsciiDoc documentation files.
 
 ## Prerequisites
 
 * A Python installation ($\ge$ v3) 
-* Install script specific python modules `jsonschema` & `PyYaml` .  Can be install using `pip install -r requirements.txt`
+* Python modules `jsonschema` & `PyYaml` .  Can be installed using `pip install -r requirements.txt`
 
 ## Usage Examples
 
-### Header file generation
+### C Header file generation
 
-Builds a set of header files, placing them in default directory `./output`
+Build a set of C header files, placing them in the default directory `./output`
 
 `python3 parser.py ./test_data/simple.rvm-csi.yaml`
 
-### Adoc file generation
+### AsciiDoc file generation
 
-Builds a set of header files, placing them in default directory `./adoc_output`
+Build AsciiDoc documentation, placing the files in default directory `./adoc_output`.
 
 `python3 parser.py --generate-docs ./test_data/simple.rvm-csi.yaml`
 
-Linked HTML docs can be generated from the .adoc files e.g.
+The top level is `index.adoc` which links to module specific files in a `/modules` subfolder
 
-`cd ./adoc_output`
-`asciidoctor *.adoc`
+The .adoc files can be transformed to HTML using [Asciidoctor](https://asciidoctor.org), for example:
+
+`find . -name *.adoc | xargs asciidoctor`
+
+### Further help
+
+`python parser.py --help` will display the application help files 
 
 ## Testing
 
-*NB incomplete*
+*NB requires further work, possible refactoring into a different directory*
 
 Top level parser tests:
 

--- a/spec-schema/parser/requirements.txt
+++ b/spec-schema/parser/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema==4.17.0
+PyYAML==6.0

--- a/spec-schema/parser/test_data/invalid.rvm-csi.yaml
+++ b/spec-schema/parser/test_data/invalid.rvm-csi.yaml
@@ -1,0 +1,10 @@
+version: 1
+c-api-title: RVM-CSI API
+c-documentation-title: RVM-CSI API
+boilerplate: >
+  Copyright (c) RISC-V International 2022.
+  Creative Commons License
+notes:
+  - This is an example YAML used to demonstrate validation against the schema, rvm-csi.schema.json.
+  - It does not reflect the real API specification, but the real specification will have similar form.
+another-duff-property: dummy

--- a/spec-schema/parser/test_data/simple.rvm-csi.yaml
+++ b/spec-schema/parser/test_data/simple.rvm-csi.yaml
@@ -1,0 +1,105 @@
+version: 1
+c-api-title: RVM-CSI API
+c-documentation-title: RVM-CSI API
+boilerplate: >
+  Copyright (c) RISC-V International 2022.
+  Creative Commons License
+notes:
+  - This is an example YAML used to demonstrate validation against the schema, rvm-csi.schema.json.
+  - It does not reflect the real API specification, but the real specification will have similar form.
+modules:
+  - name: Common header file describing CSI API.
+    c-specific: true
+    c-filename: csi.h
+    description: >
+      This header should not be included directly by users.  Rather, users include
+      <platform_name>.h, which is supplied by a Board Support Pack (BSP) for a specific
+      platform.  This in turn includes a series of platform-specific headers culminating
+      in this common one.
+    c-include-files:
+      - filename: csi_interrupts.h
+        system-header: false
+  - name: General-Purpose Definitions for use in CSI code
+    description: >
+      This file is included prior to all other headers and just contains general-purpose definitions.
+    c-specific: true
+    c-filename: csi_defs.h
+    c-type-declarations:
+    - name: csi_status_t
+      description: An example of a enumeration definition with assigned values 
+      type: enum
+      enum-members:
+      - name: CSI_SUCCESS
+        value: 0
+      - name: CSI_NOT_IMPLEMENTED
+        value: -1
+      - name: CSI_ERROR
+        value: -2
+    - name: csi_check_t
+      type: enum
+      description: An example of a enumeration definition
+      enum-members:
+      - name: CSI_SUCCESS
+      - name: CSI_NOT_IMPLEMENTED
+      - name: CSI_ERROR
+    - name: csi_timer_count_t
+      description: An example of an unsigned definition
+      type: unsigned  
+    - name: csi_dummy_t
+      type: struct
+      description: An example of a structure definition
+      struct-members:
+         - name: a
+           type: unsigned *
+         - name: b
+           type: uint32_t
+         - name: memory
+           type: csi_memory_t *
+         - name: status
+           type: csi_status_t *   
+  - name: Interrupt and Timer Support
+    description: Interrupt and timer support operations
+    c-specific: false
+    c-filename: csi_interrupts.h
+    functions:
+      - name: csi_register_isr
+        description: >
+          Registers a user-supplied function <code>isr</code>that will be called by the base trap handler on receipt
+          of a trap arising from a given signal
+        c-specific-notes:
+          - >
+            This function uses the CSI base trap handler so is surrounded by <code>#ifndef CUSTOM_BASE_TRAP_HANDLER</code>.
+            It transparently deals with routing the desired signal to the hart and enabling the interrupt
+            (by internally calling <code>cs_route_signal()</code>).
+        c-params:
+          - name: isr
+            description: User's Interrupt Service Routine
+            type: csi_isr_t *
+          - name: isr_ctx
+            description: Context pointer to pass into user's ISR
+            type: void *
+          - name: signal
+            description: Enumerated signal to be handled by this ISR
+            type: csi_signal_t
+            notes:
+            - example of function parameter notes
+        c-return-type: 
+          description: Status of register isr
+          type: csi_status_t
+  - name: Platform Discovery
+    description: Functions for discovery of platform characteristics
+    c-specific: false
+    c-filename: csi_discovery.h
+    c-type-declarations:
+    - name: csi_timer_count_t
+      type: unsigned
+      description: An example of an unsigned type definition
+      type-prefixes:
+      - volatile
+      - static
+    functions:
+      - name: csi_get_cpu_clk_freq
+        description: Returns CPU clock frequency in Hz.
+        c-return-type: 
+          description: clock frequency in Hz
+          type: const unsigned

--- a/spec-schema/parser/test_data/simple.rvm-csi.yaml
+++ b/spec-schema/parser/test_data/simple.rvm-csi.yaml
@@ -64,7 +64,7 @@ modules:
           - name: isr
             description: Status to set
             type: csi_status_t
-          c-return-type: 
+          c-return-value: 
             description: Not applicable
             type: void
 
@@ -94,7 +94,7 @@ modules:
             type: csi_signal_t
             notes:
             - example of function parameter notes
-        c-return-type: 
+        c-return-value: 
           description: Status of register isr
           type: csi_status_t
   - name: Platform Discovery
@@ -108,6 +108,6 @@ modules:
     functions:
       - name: csi_get_cpu_clk_freq
         description: Returns CPU clock frequency in Hz.
-        c-return-type: 
+        c-return-value: 
           description: clock frequency in Hz
           type: const unsigned

--- a/spec-schema/parser/test_data/simple.rvm-csi.yaml
+++ b/spec-schema/parser/test_data/simple.rvm-csi.yaml
@@ -105,9 +105,6 @@ modules:
     - name: csi_timer_count_t
       type: unsigned
       description: An example of an unsigned type definition
-      type-prefixes:
-      - volatile
-      - static
     functions:
       - name: csi_get_cpu_clk_freq
         description: Returns CPU clock frequency in Hz.

--- a/spec-schema/parser/test_data/simple.rvm-csi.yaml
+++ b/spec-schema/parser/test_data/simple.rvm-csi.yaml
@@ -56,7 +56,18 @@ modules:
          - name: memory
            type: csi_memory_t *
          - name: status
-           type: csi_status_t *   
+           type: csi_status_t *
+    functions:
+        - name: csi_set_status
+          description: Set some arbitrary status
+          c-params:
+          - name: isr
+            description: Status to set
+            type: csi_status_t
+          c-return-type: 
+            description: Not applicable
+            type: void
+
   - name: Interrupt and Timer Support
     description: Interrupt and timer support operations
     c-specific: false

--- a/spec-schema/rvm-csi.schema.json
+++ b/spec-schema/rvm-csi.schema.json
@@ -38,18 +38,18 @@
           }
         }
       },
-      "c-function-return-type": {
-        "description": "C function return type",
+      "c-function-return-value": {
+        "description": "Value returned by C function",
         "type": "object",
         "additionalProperties": false,
         "required": ["description", "type"],
         "properties": {
           "description": {
-            "description": "C-specific function return type description",
+            "description": "C-specific function return value description",
             "type": "string"
           },
           "type": {
-            "description": "C function return type",
+            "description": "Return type",
             "type": "string"
           }
         }
@@ -87,11 +87,11 @@
               "$ref": "#/definitions/c-function-param"
             }
           },
-          "c-return-type": {
+          "c-return-value": {
             "description": "C function return type",
             "type": "object",
             "items":  {
-              "$ref": "#/definitions/c-function-return-type"
+              "$ref": "#/definitions/c-function-return-value"
             }
           }
         }

--- a/spec-schema/rvm-csi.schema.json
+++ b/spec-schema/rvm-csi.schema.json
@@ -15,6 +15,8 @@
       "c-function-param": {
         "description": "C function parameter",
         "type": "object",
+        "additionalProperties": false,
+        "required": ["name","description","type"],
         "properties": {
           "name": {
             "description": "C-specific function parameter name",
@@ -36,9 +38,27 @@
           }
         }
       },
+      "c-function-return-type": {
+        "description": "C function return type",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["description", "type"],
+        "properties": {
+          "description": {
+            "description": "C-specific function return type description",
+            "type": "string"
+          },
+          "type": {
+            "description": "C function return type",
+            "type": "string"
+          }
+        }
+      },
       "function": {
         "description": "Language-independent function description",
         "type": "object",
+        "additionalProperties": false,
+        "required": ["name","description"],
         "properties": {
           "name": {
             "description": "Function name (common across language implementations)",
@@ -69,7 +89,10 @@
           },
           "c-return-type": {
             "description": "C function return type",
-            "type": "string"
+            "type": "object",
+            "items":  {
+              "$ref": "#/definitions/c-function-return-type"
+            }
           }
         }
       },
@@ -86,6 +109,7 @@
       "c-struct-member": {
         "description": "Member of a C structure",
         "type": "object",
+        "required": ["name", "type"],
         "properties": {
           "name": {
             "description": "C structure member variable name",
@@ -93,13 +117,15 @@
           },
           "type": {
             "description": "C structure member variable type",
-            "$ref": "#/definitions/c-type"
+            "type": "string"
           }
         }
       },
       "c-enum-entry": {
         "description": "Member of a C enum",
         "type": "object",
+        "required": ["name"],
+        "additionalProperties": false,
         "properties": {
           "name": {
             "description": "C enum member name",
@@ -114,9 +140,15 @@
       "c-type-declaration": {
         "description": "C type declaration",
         "type": "object",
+        "required": ["name", "type", "description"],
+        "additionalProperties": false,
         "properties": {
           "name": {
             "description": "C type name",
+            "type": "string"
+          },
+          "description": {
+            "description": "Type declaration description",
             "type": "string"
           },
           "type": {
@@ -145,6 +177,8 @@
       "c-include-file": {
         "description": "C include file",
         "type": "object",
+        "additionalProperties": false,
+        "required": ["filename", "system-header"],
         "properties": {
           "filename": {
             "description": "Include file name",
@@ -159,6 +193,8 @@
       "module": {
         "description": "The API may be divided into modules, each covering a different functional area.  Modules may also equate to files.  A module without functions is permissible, for example to create a top-level header file.",
         "type": "object",
+        "additionalProperties": false,
+        "required": ["name","description"],
         "properties": {
           "name": {
             "description": "Module name",
@@ -209,6 +245,8 @@
         }
       }
     },
+    "additionalProperties": false,
+    "required": ["version","boilerplate"],
     "properties": {
       "version": {
         "description": "Specification version number",
@@ -244,6 +282,5 @@
           "$ref": "#/definitions/module"
         }
       }
-    },
-    "additionalProperties": false
+    }
 }


### PR DESCRIPTION
This PR covers two changes:
1. Updates to the JSON schema:
- Use "additionalProperties" & "required" fields to tighten spec
- Extend "c-return-type" to be an object so it can carry description field for use in documentation
- Alter struct members to be string so they can use a typedef'd field e.g. `csi_status_t *status_ptr`
- Add description field to "c-type-declaration" for use in documentation

2. First implementation of python parsing script to build header & adoc files 